### PR TITLE
cryptagls4java: Target für generierte Klassen auf Java 1.5 fixiert

### DIFF
--- a/thirdparty/cryptalgs4java/build.xml
+++ b/thirdparty/cryptalgs4java/build.xml
@@ -14,6 +14,7 @@
     <target name="compile">
         <mkdir dir="${classes}"/>
         <javac srcdir="${srccode}" destdir="${classes}" 
+               source="1.5" target="1.5"
                debug="on" encoding="UTF-8"
                deprecation="on" 
                includeAntRuntime="no" />


### PR DESCRIPTION
Im thirdparty-Modul cryptalgs4java Version der generierten Klassen auf Java 1.5 fixiert (notwendig für Zielsysteme mit älterer Java-Version, analog zu Commit 654e43ec92).
