### PR TITLE
Index-Parameter auf Highlevel-Ebene hinzugefügt

### DIFF
--- a/src/messages.properties
+++ b/src/messages.properties
@@ -124,6 +124,7 @@ EXCMSG_NOVALUE=no value given for element {0}
 EXCMSG_OVERWRITE=trying to overwrite value \"{1}\" of {0} with \"{2}\"
 EXCMSG_PARAM_EMPTY=parameter {0} of job {1} must not be empty
 EXCMSG_PARAM_NOTNEEDED=parameter {0} not required for job {1}
+EXCMSG_PARAM_NOTINDEXED=parameter {0} of job {1} is not indexed
 EXCMSG_PASSPORT_INST=can not instantiate passport of type {0}
 EXCMSG_PASSPORT_INSTDATAERR=initialization of institute data failed
 EXCMSG_PASSPORT_INSTSAVEERR=error while storing institute data on chipcard

--- a/src/messages_de.properties
+++ b/src/messages_de.properties
@@ -124,6 +124,7 @@ EXCMSG_NOVALUE=kein Wert für Element {0} angegeben
 EXCMSG_OVERWRITE=überschreiben des Wertes \"{1}\" im Element {0} mit \"{2}\" nicht möglich
 EXCMSG_PARAM_NOTNEEDED=Parameter {0} wird für Job {1} nicht benötigt
 EXCMSG_PARAM_EMPTY=Parameter {0} für Job {1} darf nicht leer sein
+EXCMSG_PARAM_NOTINDEXED=Parameter {0} für Job {1} unterstützt keinen Index
 EXCMSG_PASSPORT_INST=kann kein Passport des Typs {0} instanziieren
 EXCMSG_PASSPORT_INSTDATAERR=Fehler beim Initialisieren der Instituts-Daten
 EXCMSG_PASSPORT_INSTSAVEERR=Fehler beim Schreiben der Instituts-Daten auf die Chipkarte

--- a/src/org/kapott/hbci/GV/AbstractGVLastSEPA.java
+++ b/src/org/kapott/hbci/GV/AbstractGVLastSEPA.java
@@ -65,21 +65,21 @@ public abstract class AbstractGVLastSEPA extends AbstractSEPAGV
     	addConstraint("src.bic",         "sepa.src.bic",  null,   LogFilter.FILTER_MOST);
     	addConstraint("src.iban",        "sepa.src.iban",  null,  LogFilter.FILTER_IDS);
     	addConstraint("src.name",        "sepa.src.name",  null,  LogFilter.FILTER_IDS);
-    	addConstraint("dst.bic",         "sepa.dst.bic",   null,  LogFilter.FILTER_MOST);
-    	addConstraint("dst.iban",        "sepa.dst.iban",  null,  LogFilter.FILTER_IDS);
-    	addConstraint("dst.name",        "sepa.dst.name",  null,  LogFilter.FILTER_IDS);
-    	addConstraint("btg.value",       "sepa.btg.value", null,  LogFilter.FILTER_NONE);
-    	addConstraint("btg.curr",        "sepa.btg.curr",  "EUR", LogFilter.FILTER_NONE);
-    	addConstraint("usage",           "sepa.usage",     null,  LogFilter.FILTER_NONE);
+    	addConstraint("dst.bic",         "sepa.dst.bic",   null,  LogFilter.FILTER_MOST, true);
+    	addConstraint("dst.iban",        "sepa.dst.iban",  null,  LogFilter.FILTER_IDS,  true);
+    	addConstraint("dst.name",        "sepa.dst.name",  null,  LogFilter.FILTER_IDS,  true);
+    	addConstraint("btg.value",       "sepa.btg.value", null,  LogFilter.FILTER_NONE, true);
+    	addConstraint("btg.curr",        "sepa.btg.curr",  "EUR", LogFilter.FILTER_NONE, true);
+    	addConstraint("usage",           "sepa.usage",     null,  LogFilter.FILTER_NONE, true);
     
     	addConstraint("sepaid",          "sepa.sepaid",        getSEPAMessageId(),      LogFilter.FILTER_NONE);
-    	addConstraint("endtoendid",      "sepa.endtoendid",    ENDTOEND_ID_NOTPROVIDED, LogFilter.FILTER_IDS);
-        addConstraint("creditorid",      "sepa.creditorid",    null,                    LogFilter.FILTER_IDS);
-    	addConstraint("mandateid",       "sepa.mandateid",     null,                    LogFilter.FILTER_IDS);
+    	addConstraint("endtoendid",      "sepa.endtoendid",    ENDTOEND_ID_NOTPROVIDED, LogFilter.FILTER_IDS,  true);
+        addConstraint("creditorid",      "sepa.creditorid",    null,                    LogFilter.FILTER_IDS,  true);
+    	addConstraint("mandateid",       "sepa.mandateid",     null,                    LogFilter.FILTER_IDS,  true);
     	
     	// Datum als java.util.Date oder als ISO-Date-String im Format yyyy-MM-dd
-    	addConstraint("manddateofsig",   "sepa.manddateofsig", null,                    LogFilter.FILTER_NONE);
-    	addConstraint("amendmandindic",  "sepa.amendmandindic",Boolean.toString(false), LogFilter.FILTER_NONE);
+    	addConstraint("manddateofsig",   "sepa.manddateofsig", null,                    LogFilter.FILTER_NONE, true);
+    	addConstraint("amendmandindic",  "sepa.amendmandindic",Boolean.toString(false), LogFilter.FILTER_NONE, true);
     	
     	// Moegliche Werte:
     	//   FRST = Erst-Einzug

--- a/src/org/kapott/hbci/GV/AbstractSEPAGV.java
+++ b/src/org/kapott/hbci/GV/AbstractSEPAGV.java
@@ -8,6 +8,7 @@ import java.util.Date;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 
 import org.kapott.hbci.GV.generators.ISEPAGenerator;
 import org.kapott.hbci.GV.generators.SEPAGeneratorFactory;
@@ -35,7 +36,7 @@ public abstract class AbstractSEPAGV extends HBCIJobImpl
     private Properties sepaParams    = new Properties();
     private PainVersion pain         = null;
     private ISEPAGenerator generator = null;
-    
+
     /**
      * Liefert die Default-PAIN-Version, das verwendet werden soll,
      * wenn von der Bank keine geliefert wurden.
@@ -302,14 +303,15 @@ public abstract class AbstractSEPAGV extends HBCIJobImpl
     }
 
     /**
-     * @see org.kapott.hbci.GV.HBCIJobImpl#addConstraint(java.lang.String, java.lang.String, java.lang.String, int)
+     * @see org.kapott.hbci.GV.HBCIJobImpl#addConstraint(java.lang.String, java.lang.String, java.lang.String, int, boolean)
      * Ueberschrieben, um die Default-Werte der SEPA-Parameter vorher rauszufischen und in "this.sepaParams" zu
      * speichern. Die brauchen wir "createSEPAFromParams" beim Erstellen des XML - sie wuerden dort sonst aber
      * fehlen, weil Default-Werte eigentlich erst in "verifyConstraints" uebernommen werden.
      */
-    protected void addConstraint(String frontendName, String destinationName, String defValue, int logFilterLevel)
+    @Override
+    protected void addConstraint(String frontendName, String destinationName, String defValue, int logFilterLevel, boolean indexed)
     {
-        super.addConstraint(frontendName, destinationName, defValue, logFilterLevel);
+        super.addConstraint(frontendName, destinationName, defValue, logFilterLevel, indexed);
         
         if (destinationName.startsWith("sepa.") && defValue != null)
         {

--- a/src/org/kapott/hbci/GV/GVUebSEPA.java
+++ b/src/org/kapott/hbci/GV/GVUebSEPA.java
@@ -97,15 +97,15 @@ public class GVUebSEPA extends AbstractSEPAGV
         addConstraint("src.bic",   "sepa.src.bic",   null, LogFilter.FILTER_MOST);
         addConstraint("src.iban",  "sepa.src.iban",  null, LogFilter.FILTER_IDS);
         addConstraint("src.name",  "sepa.src.name",  null, LogFilter.FILTER_IDS);
-        addConstraint("dst.bic",   "sepa.dst.bic",   null, LogFilter.FILTER_MOST);
-        addConstraint("dst.iban",  "sepa.dst.iban",  null, LogFilter.FILTER_IDS);
-        addConstraint("dst.name",  "sepa.dst.name",  null, LogFilter.FILTER_IDS);
-        addConstraint("btg.value", "sepa.btg.value", null, LogFilter.FILTER_NONE);
-        addConstraint("btg.curr",  "sepa.btg.curr",  "EUR", LogFilter.FILTER_NONE);
-        addConstraint("usage",     "sepa.usage",     null, LogFilter.FILTER_NONE);
+        addConstraint("dst.bic",   "sepa.dst.bic",   null, LogFilter.FILTER_MOST, true);
+        addConstraint("dst.iban",  "sepa.dst.iban",  null, LogFilter.FILTER_IDS, true);
+        addConstraint("dst.name",  "sepa.dst.name",  null, LogFilter.FILTER_IDS, true);
+        addConstraint("btg.value", "sepa.btg.value", null, LogFilter.FILTER_NONE, true);
+        addConstraint("btg.curr",  "sepa.btg.curr",  "EUR", LogFilter.FILTER_NONE, true);
+        addConstraint("usage",     "sepa.usage",     null, LogFilter.FILTER_NONE, true);
       
         //Constraints für die PmtInfId (eindeutige SEPA Message ID) und EndToEndId (eindeutige ID um Transaktion zu identifizieren)
         addConstraint("sepaid",    "sepa.sepaid",      getSEPAMessageId(),      LogFilter.FILTER_NONE);
-        addConstraint("endtoendid", "sepa.endtoendid", ENDTOEND_ID_NOTPROVIDED, LogFilter.FILTER_NONE);
+        addConstraint("endtoendid", "sepa.endtoendid", ENDTOEND_ID_NOTPROVIDED, LogFilter.FILTER_NONE, true);
     }
 }

--- a/src/org/kapott/hbci/GV/HBCIJob.java
+++ b/src/org/kapott/hbci/GV/HBCIJob.java
@@ -200,7 +200,22 @@ public interface HBCIJob
      @param paramName der Name des zu setzenden Parameters.
      @param value Wert, auf den der Parameter gesetzt werden soll */
     public void setParam(String paramName,String value);
-    
+
+    /** <p>Setzen eines Job-Parameters. Für alle Highlevel-Jobs ist in der Package-Beschreibung zum
+     Package <code>org.kapott.hbci.GV</code> eine Auflistung aller Jobs und deren Parameter zu finden.
+     Für alle Lowlevel-Jobs kann eine Liste aller Parameter entweder mit dem Tool
+     {@link org.kapott.hbci.tools.ShowLowlevelGVs} oder zur Laufzeit durch Aufruf
+     der Methode {@link org.kapott.hbci.manager.HBCIHandler#getLowlevelJobParameterNames(String)} 
+     ermittelt werden.</p>
+     <p>Bei Verwendung dieser oder einer der anderen <code>setParam()</code>-Methoden werden zusätzlich
+     einige der Job-Restriktionen (siehe {@link #getJobRestrictions()}) analysiert. Beim Verletzen einer
+     der überprüften Einschränkungen wird eine Exception mit einer entsprechenden Meldung erzeugt.
+     Diese Überprüfung findet allerdings nur bei Highlevel-Jobs statt.</p>
+     @param paramName der Name des zu setzenden Parameters.
+     @param index der Index bei Index-Parametern, sonst <code>null</code>
+     @param value Wert, auf den der Parameter gesetzt werden soll */
+    public void setParam(String paramName,Integer index,String value);
+
     /** <p>Hinzufügen dieses Jobs zu einem HBCI-Dialog. Diese Methode arbeitet analog zu 
         {@link #addToQueue(String)}, nur dass hier
         die <code>customerid</code> mit der Kunden-ID vorbelegt ist, wie sie


### PR DESCRIPTION
Index-Parameter wurden auf Highlevel-Ebene hinzugefügt. Mittels setParam(String paramName, Integer index, String value) kann ein entsprechender Index-Parameter gesetzt werden.

addConstraint() hat einen weiteren boolean-Parameter, der auf true gesetzt wird, wenn der Parameter indexfähig ist. Wird setParam() mit einem Index bei einem nicht index-fähigen Parameter aufgerufen, wird eine entsprechende Fehlermeldung zurückgeliefert.

TODOs:
- Defaultwerte werden bei fehlenden Index-Parametern nicht automatisch gesetzt.
- SEPA-Geschäftsvorfälle mit Einzeltransaktion (LastSEPA, UebSEPA) akzeptieren dennoch Index-Parameter. Hier müsste es eine Möglichkeit geben, Constraints erst nachträglich in den abgeleiteten Multi-Klassen auf index=true zu setzen.
