### PR TITLE
Methoden zur Prüfung von Creditor IDs.

### DIFF
--- a/src/org/kapott/hbci/manager/AccountCRCAlgs.java
+++ b/src/org/kapott/hbci/manager/AccountCRCAlgs.java
@@ -1612,4 +1612,32 @@ public class AccountCRCAlgs
     	
     	return rest.intValue()==1;
     }
+    
+    public static boolean checkCreditorId(String creditorId)
+    {
+        //DE: Immer Länge 18
+        if ("DE".equals(creditorId.substring(0,2).toUpperCase()) && creditorId.length()!=18)
+            return false;
+                
+        //Rest wie bei IBAN
+        StringBuffer s=new StringBuffer();
+        
+        s.append(creditorId.substring(7));
+        s.append(creditorId.substring(0,4));
+        
+        StringBuffer s2=new StringBuffer();
+        for (int i=0; i<s.length(); i++) {
+            char ch=s.charAt(i);
+            if (ch>='0' && ch<='9') {
+                s2.append(ch);
+            } else {
+                s2.append(ch-'A'+10);
+            }
+        }
+        
+        BigInteger x=new BigInteger(s2.toString());
+        BigInteger rest=x.mod(new BigInteger("97"));
+        
+        return rest.intValue()==1;
+    }
 }

--- a/src/org/kapott/hbci/manager/HBCIUtils.java
+++ b/src/org/kapott/hbci/manager/HBCIUtils.java
@@ -1656,6 +1656,15 @@ public final class HBCIUtils
     	return AccountCRCAlgs.checkIBAN(iban);
     }
     
+    /** Überprüfen der Gültigkeit einer Gläubiger-ID. Diese Methode prüft anhand eines
+     * Prüfziffer-Algorithmus, ob die übergebene ID prinzipiell gültig ist.
+     * @return <code>false</code> wenn der Prüfzifferntest fehlschlägt, sonst
+     * <code>true</code>  */
+    public static boolean checkCredtitorIdCRC(String iban)
+    {
+        return AccountCRCAlgs.checkCreditorId(iban);
+    }
+
     private static void refreshBLZList(ClassLoader cl)
         throws IOException
     {

--- a/test/hbci4java/manager/TestAccountCRCAlgs.java
+++ b/test/hbci4java/manager/TestAccountCRCAlgs.java
@@ -1,0 +1,29 @@
+package hbci4java.manager;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.kapott.hbci.manager.AccountCRCAlgs;
+
+public class TestAccountCRCAlgs {
+
+    @Test
+    public void test001() {
+        //Beispiel Bundesbank
+        Assert.assertTrue(AccountCRCAlgs.checkCreditorId("DE98ZZZ09999999999"));
+        //Bund
+        Assert.assertTrue(AccountCRCAlgs.checkCreditorId("DE09ZZZ00000000001"));
+    }
+
+    //Test, das alle anderen Prüfziffern bei "DE98ZZZ09999999999" falsch sind
+    @Test
+    public void test002() {
+        String prefix="DE";
+        String postfix="ZZZ09999999999";
+        for (int i=2; i<98; i++) {
+            String mid = String.valueOf(i);
+            if (i<10) mid = "0"+mid;
+            Assert.assertFalse(prefix+mid+postfix, AccountCRCAlgs.checkCreditorId(prefix+mid+postfix));
+        }
+    }
+
+}


### PR DESCRIPTION
Es wird nur bei deutschen Creditor IDs (Gläubiger-Identifikationsnummer) auf die korrekte Länge geprüft (mir liegen keine Informationen zu anderen Ländern vor).
siehe auch http://www.onlinebanking-forum.de/forum/topic.php?t=17261

Es wird nicht geprüft, ob die Prüfziffern zwischen 02 und 98 sind!

Dies ist der Teil für hbci4java mit der konkreten Implementierung und einfachen Tests.
