### PR TITLE
Add timeout for HTTPS connect and read

### DIFF
--- a/src/org/kapott/hbci/comm/CommPinTan.java
+++ b/src/org/kapott/hbci/comm/CommPinTan.java
@@ -54,6 +54,9 @@ public final class CommPinTan
     // nicht verifiziert werden sollen
     private HostnameVerifier   myHostnameVerifier;
     
+    // Timeout for HTTP connect and read operations in milliseconds
+    private final static int HTTP_TIMEOUT = 60000;
+
     
     public CommPinTan(HBCIPassportInternal parentPassport)
     {
@@ -109,6 +112,8 @@ public final class CommPinTan
 
             HBCIUtils.log("connecting to server",HBCIUtils.LOG_DEBUG);
             conn=(HttpURLConnection)url.openConnection();
+            conn.setConnectTimeout(HTTP_TIMEOUT);
+            conn.setReadTimeout(HTTP_TIMEOUT);
             
             boolean checkCert=((AbstractPinTanPassport)getParentPassport()).getCheckCert();
             boolean debugging=((PinTanSSLSocketFactory)this.mySocketFactory).debug();


### PR DESCRIPTION
At least with OpenJDK 7u65 under Debian 7 there is no default timeout for the HTTP operation. Maybe it would be nicer to have a configurable timeout, but as I don't have a good understanding of the architecture I start off with a fixed timeout.
