### PR TITLE
Postbank HBCI2.2+ -> FinTS 3.0

### DIFF
--- a/src/blz.properties
+++ b/src/blz.properties
@@ -1464,7 +1464,7 @@
 42640048=Commerzbank|Recklinghausen, Westf|COBADEFF426|13|hbci.commerzbank.de||300||
 26261492=Volksbank Einbeck|Einbeck|GENODEF1EIN|28|hbci.gad.de|https://hbci-pintan.gad.de/cgi-bin/hbciservlet|300|300|
 50210162=SEB TZN MB Frankfurt|Frankfurt am Main|ESSEDE5FXXX|09|||||
-10010010=Postbank|Berlin|PBNKDEFF100|24||https://hbci.postbank.de/banking/hbci.do|220|plus|
+10010010=Postbank|Berlin|PBNKDEFF100|24||https://hbci.postbank.de/banking/hbci.do|300|300|
 35070024=Deutsche Bank Privat und Geschäftskunden|Duisburg|DEUTDEDB350|63|193.150.167.8|https://fints.deutsche-bank.de/|300|300|
 72261754=Raiffeisenbank Rain am Lech|Rain, Lech|GENODEF1RLH|88|hbci01.fiducia.de|https://hbci11.fiducia.de/cgi-bin/hbciservlet|300|300|
 74190000=GenoBank DonauWald|Viechtach|GENODEF1DGV|88|hbci01.fiducia.de|https://hbci11.fiducia.de/cgi-bin/hbciservlet|300|300|


### PR DESCRIPTION
Needed this to successfully connect. Forum conversations also suggested that hbci/fints 3 is the current version (http://www.starmoney.de/forum/viewtopic.php?t=28002). This is probably outdated then: https://www.willuhn.de/wiki/doku.php?id=support:list:banken:misc:pintan