### PR TITLE
Toleranz von kaputten MT940-Daten erhöht

### DIFF
--- a/src/org/kapott/hbci/swift/Swift.java
+++ b/src/org/kapott/hbci/swift/Swift.java
@@ -47,7 +47,7 @@ public class Swift
     public static String getTagValue(String st,String tag,int counter)
     {
         String  ret=null;
-        Pattern patternNLTag=Pattern.compile("\\r\\n(-)?:\\d{2}[A-Z]?:"); // Zu dem "(-)?" siehe TestBrokenMT940.java
+        Pattern patternNLTag=Pattern.compile("\\r\\n(-|-\\r\\n)?:\\d{2}[A-Z]?:"); // Zu dem "(-)?" siehe TestBrokenMT940.java
         
         int endpos=0;
         while (true) {

--- a/test/hbci4java/swift/TestBrokenMT940.java
+++ b/test/hbci4java/swift/TestBrokenMT940.java
@@ -14,11 +14,21 @@ import org.kapott.hbci.swift.Swift;
 /**
  * Testet das Parsen von kaputten MT940-Strings, die etwa so aussehen:
  * 
+ * Test 1: Korrekter Aufbau
+ * 
+ * Test 2: CRLF-
  * :60M:C140106EUR1,00
  * -:61:1401060106CR1,00N062NONREF
- * 
+ *
  * Das "-" am Beginn der zweiten Zeile ist falsch. Einige Banken
  * senden sowas aber. Irgendwie muessen wir das tolerieren.
+ * 
+ * Test 3: CRLF-CRLF (Bank: Kreissparkasse Grafschaft Bentheim zu Nordhorn)
+ * :60M:C140106EUR1,00
+ * -
+ * :61:1401060106CR1,00N062NONREF
+ * 
+ * Das "-" in der zweiten Zeile ist ebenfalls falsch
  * 
  */
 public class TestBrokenMT940
@@ -45,6 +55,19 @@ public class TestBrokenMT940
     public void test002() throws Exception
     {
         String st = "\r\n:60M:C140106EUR1,00\r\n-:61:1401060106CR5,00N062NONREF";
+        String value = Swift.getTagValue(st,"60M",0);
+        Assert.assertEquals("C140106EUR1,00",value);
+    }
+    
+    /**
+     * Ungueltiger Aufbau.
+     * Muss aber trotzdem korrekt geparst werden.
+     * @throws Exception
+     */
+    @Test
+    public void test003() throws Exception
+    {
+        String st = "\r\n:60M:C140106EUR1,00\r\n-\r\n:61:1401060106CR5,00N062NONREF";
         String value = Swift.getTagValue(st,"60M",0);
         Assert.assertEquals("C140106EUR1,00",value);
     }


### PR DESCRIPTION
Zeilen können folgendermaßen aussehen (Kreissparkasse Grafschaft Bentheim zu Nordhorn)
:60M:C140106EUR1,00
-
:61:1401060106CR1,00N062NONREF

UnitTest ergänzt