### PR TITLE
Ersetzung von pain.008.003.02.xsd aus offiziellen Release

### DIFF
--- a/src/pain.008.003.02.xsd
+++ b/src/pain.008.003.02.xsd
@@ -3,13 +3,7 @@
 <!-- Version gemäß DFÜ-Abkommen Anlage 3, Version 2.7, gültig ab November 2013 mit Umsetzung von IBAN Only gemäß EPC SDD Core IG 7.0 bzw. SDD B2B IG 5.0 , zudem Einbau der COR1-Option durch Erweiterung Local Instrument und Erweiterung Service Level auf Externe Codeliste-->
 <!-- Mit XMLSpy v2008 rel. 2 sp2 (http://www.altova.com) am 29.11.2012 von der SIZ GmbH bearbeitet -->
 <xs:schema xmlns="urn:iso:std:iso:20022:tech:xsd:pain.008.003.02" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:iso:std:iso:20022:tech:xsd:pain.008.003.02" elementFormDefault="qualified">
-	<xs:element name="Document">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="CstmrDrctDbtInitn" type="CustomerDirectDebitInitiationV02"/>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
+	<xs:element name="Document" type="Document"/>
 	<xs:complexType name="AccountIdentificationSEPA">
 		<xs:sequence>
 			<xs:element name="IBAN" type="IBAN2007Identifier"/>
@@ -192,6 +186,11 @@ Transaction’ level.</xs:documentation>
 			</xs:element>
 			<xs:element name="Purp" type="PurposeSEPA" minOccurs="0"/>
 			<xs:element name="RmtInf" type="RemittanceInformationSEPA1Choice" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Document">
+		<xs:sequence>
+			<xs:element name="CstmrDrctDbtInitn" type="CustomerDirectDebitInitiationV02"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:simpleType name="DocumentType3CodeSEPA">


### PR DESCRIPTION
Mir ist aufgefallen, dass die generierten Klassen aus JAXB nicht mit dem eingecheckten Stand übereinstimmen. Aus irgendeinem Grund wurde das XSD angepasst, so dass es vom Original abweicht.

Wenn man die Änderung zurückrollt, stimmen die von JAXB generierten Klassen mit dem eingecheckten Stand überein. 
Von daher gehe ich davon aus, dass das XSD aus Versehen geändert wurde.

siehe http://www.ebics.de/fileadmin/unsecured/anlage3/anlage3_archiv/Anlage3_Archiv_V2_9.zip