### PR TITLE
Empfänger BIC ist bei SEPA-Überweisungen bzw Sammelüberweisungen optional.

### DIFF
--- a/src/org/kapott/hbci/GV/GVUebSEPA.java
+++ b/src/org/kapott/hbci/GV/GVUebSEPA.java
@@ -98,7 +98,7 @@ public class GVUebSEPA extends AbstractSEPAGV
         addConstraint("src.bic",   "sepa.src.bic",   null, LogFilter.FILTER_MOST);
         addConstraint("src.iban",  "sepa.src.iban",  null, LogFilter.FILTER_IDS);
         addConstraint("src.name",  "sepa.src.name",  null, LogFilter.FILTER_IDS);
-        addConstraint("dst.bic",   "sepa.dst.bic",   null, LogFilter.FILTER_MOST, true);
+        addConstraint("dst.bic",   "sepa.dst.bic",   "", LogFilter.FILTER_MOST, true);
         addConstraint("dst.iban",  "sepa.dst.iban",  null, LogFilter.FILTER_IDS, true);
         addConstraint("dst.name",  "sepa.dst.name",  null, LogFilter.FILTER_IDS, true);
         addConstraint("btg.value", "sepa.btg.value", null, LogFilter.FILTER_NONE, true);

--- a/src/org/kapott/hbci/GV/GVUebSEPA.java
+++ b/src/org/kapott/hbci/GV/GVUebSEPA.java
@@ -98,7 +98,7 @@ public class GVUebSEPA extends AbstractSEPAGV
         addConstraint("src.bic",   "sepa.src.bic",   null, LogFilter.FILTER_MOST);
         addConstraint("src.iban",  "sepa.src.iban",  null, LogFilter.FILTER_IDS);
         addConstraint("src.name",  "sepa.src.name",  null, LogFilter.FILTER_IDS);
-        addConstraint("dst.bic",   "sepa.dst.bic",   "", LogFilter.FILTER_MOST, true);
+        addConstraint("dst.bic",   "sepa.dst.bic",   "", LogFilter.FILTER_MOST, true); // Kann eventuell entfallen, da BIC optional
         addConstraint("dst.iban",  "sepa.dst.iban",  null, LogFilter.FILTER_IDS, true);
         addConstraint("dst.name",  "sepa.dst.name",  null, LogFilter.FILTER_IDS, true);
         addConstraint("btg.value", "sepa.btg.value", null, LogFilter.FILTER_NONE, true);

--- a/src/org/kapott/hbci/GV/generators/GenUebSEPA00100303.java
+++ b/src/org/kapott/hbci/GV/generators/GenUebSEPA00100303.java
@@ -171,10 +171,13 @@ public class GenUebSEPA00100303 extends AbstractSEPAGenerator
         cdtTrxTxInf.getCdtrAcct().getId().setIBAN(sepaParams.getProperty(SepaUtil.insertIndex("dst.iban", index)));
 
         //Payment Information - Credit Transfer Transaction Information - Creditor Agent
-        cdtTrxTxInf.setCdtrAgt(new BranchAndFinancialInstitutionIdentificationSEPA1());
-        cdtTrxTxInf.getCdtrAgt().setFinInstnId(new FinancialInstitutionIdentificationSEPA1());
-        cdtTrxTxInf.getCdtrAgt().getFinInstnId().setBIC(sepaParams.getProperty(SepaUtil.insertIndex("dst.bic", index)));
-
+        String dstBic = sepaParams.getProperty(SepaUtil.insertIndex("dst.bic", index));
+        if (dstBic != null && dstBic.length() > 0) // BIC ist inzwischen optional
+        {
+            cdtTrxTxInf.setCdtrAgt(new BranchAndFinancialInstitutionIdentificationSEPA1());
+            cdtTrxTxInf.getCdtrAgt().setFinInstnId(new FinancialInstitutionIdentificationSEPA1());
+            cdtTrxTxInf.getCdtrAgt().getFinInstnId().setBIC(dstBic);
+        }
 
         //Payment Information - Credit Transfer Transaction Information - Amount
         cdtTrxTxInf.setAmt(new AmountTypeSEPA());


### PR DESCRIPTION
Evtl kann der constraint in GVUebSEPA komplett entfernt werden
Generator für PAIN 001.003.03 angepasst
siehe
http://www.onlinebanking-forum.de/forum/topic.php?p=121935#real121935
Test mit Sparkasse / Deutsche Bank / Postbank erfolgreich