### PR TITLE
BIC ist bei SEPA-Lastschriften optional

### DIFF
--- a/src/org/kapott/hbci/GV/AbstractGVLastSEPA.java
+++ b/src/org/kapott/hbci/GV/AbstractGVLastSEPA.java
@@ -70,10 +70,10 @@ public abstract class AbstractGVLastSEPA extends AbstractSEPAGV
     	addConstraint("_sepadescriptor", "sepadescr", this.getPainVersion().getURN(), LogFilter.FILTER_NONE);
     	addConstraint("_sepapain",       "sepapain", null, LogFilter.FILTER_IDS);
     
-    	addConstraint("src.bic",         "sepa.src.bic",  null,   LogFilter.FILTER_MOST);
+    	addConstraint("src.bic",         "sepa.src.bic",   "",    LogFilter.FILTER_MOST);
     	addConstraint("src.iban",        "sepa.src.iban",  null,  LogFilter.FILTER_IDS);
     	addConstraint("src.name",        "sepa.src.name",  null,  LogFilter.FILTER_IDS);
-    	addConstraint("dst.bic",         "sepa.dst.bic",   null,  LogFilter.FILTER_MOST, true);
+    	addConstraint("dst.bic",         "sepa.dst.bic",   "",    LogFilter.FILTER_MOST, true);
     	addConstraint("dst.iban",        "sepa.dst.iban",  null,  LogFilter.FILTER_IDS,  true);
     	addConstraint("dst.name",        "sepa.dst.name",  null,  LogFilter.FILTER_IDS,  true);
     	addConstraint("btg.value",       "sepa.btg.value", null,  LogFilter.FILTER_NONE, true);


### PR DESCRIPTION
Die Änderung war trivial. :smile: Getestet gegen die Sparkasse mit und ohne gesetzte BIC.

`job.setParam("dst.bic", kontoBic)` funktioniert weiterhin und überträgt die BIC in der Lastschrift. Wird das `setParam("dst.bic", ...)` weggelassen, wird kein Fehler mehr geworfen, sondern wie erwartet `NOTPROVIDED` übertragen.